### PR TITLE
Add Screenshot button

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ gtk_dep = dependency('gtk+-3.0')
 handy_dep = dependency('libhandy-1', version: '>=1.0')
 wingpanel_dep = dependency('wingpanel')
 wingpanel_indicatorsdir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
+portal_dep = dependency('libportal')
 
 subdir('data')
 subdir('po')

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,7 +35,8 @@ shared_module(
         granite_dep,
         gtk_dep,
         handy_dep,
-        wingpanel_dep
+        wingpanel_dep,
+        portal_dep
     ],
     install: true,
     install_dir : wingpanel_indicatorsdir


### PR DESCRIPTION
Proof of concept for taking screenshots from quick settings using the portal. This would replace the current screenshot app.

Todo:
- [ ] Actually save the screenshot to screenshots
- [ ] Fix the application sender so that notifications show a screenshot icon badge
- [ ] Provide a .desktop with the screenshot app's actions
- [ ] Add a copy to clipboard action?
- [ ] Review other feedback from https://github.com/elementary/screenshot/pull/253