### PR TITLE
Manually add resourced icons to path

### DIFF
--- a/data/quick-settings.gresource.xml
+++ b/data/quick-settings.gresource.xml
@@ -5,7 +5,7 @@
   </gresource>
 </gresources>
 <gresources>
-  <gresource prefix="org/elementary/wingpanel/icons">
+  <gresource prefix="/org/elementary/wingpanel/icons">
     <file alias="scalable/status/dark-mode-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/dark-mode.svg</file>
     <file alias="scalable/status/system-suspend-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/system-suspend.svg</file>
     <file alias="scalable/status/quick-settings-symbolic.svg" compressed="true" preprocess="xml-stripblanks">icons/quick-settings.svg</file>

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -19,6 +19,10 @@ public class QuickSettings.Indicator : Wingpanel.Indicator {
     construct {
         GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
         GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+
+        // Prevent a race that skips automatic resource loading
+        // https://github.com/elementary/wingpanel-indicator-bluetooth/issues/203
+        Gtk.IconTheme.get_default ().add_resource_path ("/org/elementary/wingpanel/icons");
     }
 
     public override Gtk.Widget get_display_widget () {


### PR DESCRIPTION
For some reasons neither `quick-settings-symbolic` nor `dark-mode-symbolic` shows for me in login screen on my laptop. This fixes it.

It looks this is exactly the same issue as https://github.com/elementary/wingpanel-indicator-bluetooth/issues/203, which is fixed in https://github.com/elementary/wingpanel-indicator-bluetooth/pull/204.