### PR TITLE
Fix #62

### DIFF
--- a/src/Widgets/TextScale.vala
+++ b/src/Widgets/TextScale.vala
@@ -38,9 +38,21 @@ public class QuickSettings.TextScale : Gtk.Box {
         add (zoom_in_button);
 
         interface_settings = new Settings ("org.gnome.desktop.interface");
-        interface_settings.bind ("text-scaling-factor", zoom_adjustment, "value", DEFAULT);
         interface_settings.changed["text-scaling-factor"].connect (update_zoom_buttons);
         update_zoom_buttons ();
+
+        uint update_timeout_id = 0;
+        zoom_adjustment.value_changed.connect (() => {
+            if (update_timeout_id != 0) {
+                GLib.Source.remove (update_timeout_id);
+            }
+            
+            update_timeout_id = Timeout.add (500, () => {
+                update_timeout_id = 0;
+                interface_settings.set_double ("text-scaling-factor", zoom_adjustment.value);
+                return GLib.Source.REMOVE;
+            });
+        });
 
         zoom_in_button.clicked.connect (() => {
             zoom_adjustment.value += 0.05;

--- a/src/Widgets/TextScale.vala
+++ b/src/Widgets/TextScale.vala
@@ -46,7 +46,7 @@ public class QuickSettings.TextScale : Gtk.Box {
             if (update_timeout_id != 0) {
                 GLib.Source.remove (update_timeout_id);
             }
-            
+
             update_timeout_id = Timeout.add (750, () => {
                 update_timeout_id = 0;
                 interface_settings.set_double ("text-scaling-factor", zoom_adjustment.value);

--- a/src/Widgets/TextScale.vala
+++ b/src/Widgets/TextScale.vala
@@ -47,7 +47,7 @@ public class QuickSettings.TextScale : Gtk.Box {
                 GLib.Source.remove (update_timeout_id);
             }
             
-            update_timeout_id = Timeout.add (500, () => {
+            update_timeout_id = Timeout.add (750, () => {
                 update_timeout_id = 0;
                 interface_settings.set_double ("text-scaling-factor", zoom_adjustment.value);
                 return GLib.Source.REMOVE;

--- a/src/Widgets/TextScale.vala
+++ b/src/Widgets/TextScale.vala
@@ -38,6 +38,7 @@ public class QuickSettings.TextScale : Gtk.Box {
         add (zoom_in_button);
 
         interface_settings = new Settings ("org.gnome.desktop.interface");
+        interface_settings.bind ("text-scaling-factor", zoom_adjustment, "value", GET);
         interface_settings.changed["text-scaling-factor"].connect (update_zoom_buttons);
         update_zoom_buttons ();
 
@@ -47,7 +48,7 @@ public class QuickSettings.TextScale : Gtk.Box {
                 GLib.Source.remove (update_timeout_id);
             }
 
-            update_timeout_id = Timeout.add (750, () => {
+            update_timeout_id = Timeout.add (300, () => {
                 update_timeout_id = 0;
                 interface_settings.set_double ("text-scaling-factor", zoom_adjustment.value);
                 return GLib.Source.REMOVE;


### PR DESCRIPTION
Fix #62 
Adding a debounce time of 500ms to make the text size change more comfortable.


https://github.com/user-attachments/assets/97f3528d-eee7-4250-b939-04fd2584da7c

