### PR TITLE
UserRow/CurrentUser: use built-in styles

### DIFF
--- a/data/Indicator.css
+++ b/data/Indicator.css
@@ -43,7 +43,3 @@ quicksettings .image-button:disabled {
 quicksettings .no-padding {
     padding: 0;
 }
-
-quicksettings .fullname-label {
-    font-weight: 700;
-}

--- a/src/Widgets/CurrentUser.vala
+++ b/src/Widgets/CurrentUser.vala
@@ -21,21 +21,15 @@
     }
 
     public CurrentUser.avatar_only () {
-        Object (
-            minimal: true,
-            valign: Gtk.Align.CENTER,
-            halign: Gtk.Align.CENTER
-        );
+        Object (minimal: true);
     }
 
     public CurrentUser () {
-        Object (
-            minimal: false
-        );
+        Object (minimal: false);
     }
 
     construct {
-        avatar = new Hdy.Avatar (minimal ? 28 : 48, null, true);
+        avatar = new Hdy.Avatar (minimal ? 32 : 48, null, true);
 
         // We want to use the user's accent, not a random color
         unowned Gtk.StyleContext avatar_context = avatar.get_style_context ();
@@ -58,12 +52,14 @@
             valign = Gtk.Align.END,
             halign = Gtk.Align.START
         };
-        fullname_label.get_style_context ().add_class ("fullname-label");
+        fullname_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         status_label = new Gtk.Label (null) {
             valign = Gtk.Align.START,
             halign = Gtk.Align.START
         };
+        status_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+        status_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
         logout_button = new Gtk.Button.from_icon_name ("system-log-out-symbolic") {
             tooltip_text = _("Log Out…"),

--- a/src/Widgets/UserRow.vala
+++ b/src/Widgets/UserRow.vala
@@ -37,12 +37,14 @@ public class QuickSettings.UserRow : Gtk.ListBoxRow {
             valign = Gtk.Align.END,
             halign = Gtk.Align.START
         };
-        fullname_label.get_style_context ().add_class ("fullname-label");
+        fullname_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         status_label = new Gtk.Label (null) {
             valign = Gtk.Align.START,
             halign = Gtk.Align.START
         };
+        status_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+        status_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
         if (user == null) {
             avatar = new Hdy.Avatar (ICON_SIZE, null, false);


### PR DESCRIPTION
Make avatar on the main page the same size as other buttons

Use built-in styles for text

![Screenshot from 2025-02-03 16 01 21](https://github.com/user-attachments/assets/81d9093c-d52f-4b8f-9945-d7efde3811d3)
![Screenshot from 2025-02-03 16 07 53](https://github.com/user-attachments/assets/dece6f36-2f4e-4ebb-8969-7a61072242e9)
