### PR TITLE
UserList: Fix updating properties

### DIFF
--- a/data/quick-settings.metainfo.xml
+++ b/data/quick-settings.metainfo.xml
@@ -42,6 +42,7 @@
         <issue url="https://github.com/elementary/quick-settings/issues/27">User List</issue>
         <issue url="https://github.com/elementary/quick-settings/issues/67">Cannot shutdown with staging updates; reboots regardless</issue>
         <issue url="https://github.com/elementary/quick-settings/issues/76">Bring back tooltip text from old session indicator</issue>
+        <issue url="https://github.com/elementary/quick-settings/issues/85">User account list attempts to log in disabled accounts</issue>
       </issues>
     </release>
 

--- a/src/Widgets/UserList.vala
+++ b/src/Widgets/UserList.vala
@@ -174,7 +174,7 @@
         user_map[uid].show ();
 
         listbox.add (user_map[uid]);
-        user_list_revealer.reveal_child = has_visible_rows ();
+        user_list_revealer.reveal_child = listbox.get_row_at_index (0) != null;
     }
 
     private void add_guest () {
@@ -191,7 +191,7 @@
         user_map[GUEST_USER_UID].show ();
 
         listbox.add (user_map[GUEST_USER_UID]);
-        user_list_revealer.reveal_child = has_visible_rows ();
+        user_list_revealer.reveal_child = listbox.get_row_at_index (0) != null;
     }
 
     private void remove_user (Act.User user) {
@@ -204,7 +204,7 @@
         user_map.unset (uid);
         listbox.remove (user_row);
         listbox.invalidate_sort ();
-        user_list_revealer.reveal_child = has_visible_rows ();
+        user_list_revealer.reveal_child = listbox.get_row_at_index (0) != null;
     }
 
     private void update_user (Act.User user) {
@@ -214,24 +214,13 @@
         }
 
         userbox.update_state.begin ();
-        user_list_revealer.reveal_child = has_visible_rows ();
+        user_list_revealer.reveal_child = listbox.get_row_at_index (0) != null;
     }
 
     public void update_all () {
         foreach (UserRow row in user_map.values) {
             row.update_state.begin ();
         }
-    }
-
-    // Users are added to the list even if they are locked
-    private bool has_visible_rows () {
-        for (int i = 0; listbox.get_row_at_index (i) != null; i++) {
-            if (listbox.get_row_at_index (i).visible = true) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public int sort_func (Gtk.ListBoxRow row1, Gtk.ListBoxRow row2) {

--- a/src/Widgets/UserList.vala
+++ b/src/Widgets/UserList.vala
@@ -71,7 +71,6 @@
 
         UserManager.get_usermanager ().user_added.connect (add_user);
         UserManager.get_usermanager ().user_removed.connect (remove_user);
-        UserManager.get_usermanager ().user_is_logged_in_changed.connect (update_user);
 
         var seat_path = Environment.get_variable ("XDG_SEAT_PATH");
         var session_path = Environment.get_variable ("XDG_SESSION_PATH");
@@ -204,16 +203,6 @@
         user_map.unset (uid);
         listbox.remove (user_row);
         listbox.invalidate_sort ();
-        user_list_revealer.reveal_child = has_visible_rows ();
-    }
-
-    private void update_user (Act.User user) {
-        var userbox = user_map[user.get_uid ()];
-        if (userbox == null) {
-            return;
-        }
-
-        userbox.update_state.begin ();
         user_list_revealer.reveal_child = has_visible_rows ();
     }
 

--- a/src/Widgets/UserList.vala
+++ b/src/Widgets/UserList.vala
@@ -71,6 +71,7 @@
 
         UserManager.get_usermanager ().user_added.connect (add_user);
         UserManager.get_usermanager ().user_removed.connect (remove_user);
+        UserManager.get_usermanager ().user_changed.connect (update_user);
 
         var seat_path = Environment.get_variable ("XDG_SEAT_PATH");
         var session_path = Environment.get_variable ("XDG_SESSION_PATH");
@@ -203,6 +204,16 @@
         user_map.unset (uid);
         listbox.remove (user_row);
         listbox.invalidate_sort ();
+        user_list_revealer.reveal_child = has_visible_rows ();
+    }
+
+    private void update_user (Act.User user) {
+        var userbox = user_map[user.get_uid ()];
+        if (userbox == null) {
+            return;
+        }
+
+        userbox.update_state.begin ();
         user_list_revealer.reveal_child = has_visible_rows ();
     }
 

--- a/src/Widgets/UserRow.vala
+++ b/src/Widgets/UserRow.vala
@@ -70,15 +70,8 @@ public class QuickSettings.UserRow : Gtk.ListBoxRow {
             avatar.set_loadable_icon (get_avatar_icon ());
 
             user.changed.connect (() => {
-                update ();
                 update_state.begin ();
             });
-
-            user.bind_property ("locked", this, "visible", BindingFlags.SYNC_CREATE | BindingFlags.INVERT_BOOLEAN);
-            user.bind_property ("locked", this, "no-show-all", BindingFlags.SYNC_CREATE);
-            user.bind_property ("real-name", avatar, "text", BindingFlags.SYNC_CREATE);
-
-            update ();
         }
 
         var grid = new Gtk.Grid () {
@@ -112,15 +105,6 @@ public class QuickSettings.UserRow : Gtk.ListBoxRow {
         }
     }
 
-    private void update () {
-        if (user == null) {
-            return;
-        }
-
-        fullname_label.label = user.real_name;
-        avatar.set_loadable_icon (get_avatar_icon ());
-    }
-
     public async void update_state () {
         state = yield get_user_state ();
 
@@ -131,6 +115,17 @@ public class QuickSettings.UserRow : Gtk.ListBoxRow {
             status_label.label = _("Logged in");
         } else {
             status_label.label = _("Logged out");
+        }
+
+        if (user != null) {
+            fullname_label.label = user.real_name;
+            avatar.text = user.real_name;
+            avatar.set_loadable_icon (get_avatar_icon ());
+            sensitive = !user.locked;
+
+            if (user.locked) {
+                status_label.label = _("Locked");
+            }
         }
 
         ((Gtk.ListBox) parent).invalidate_sort ();


### PR DESCRIPTION
Fixes #85 

* Listen to the correct user changed property
* Property bindings don't seem to work here, so move all of those to `update_state`
* remove redundant update functions
* Use `sensitive` instead of `visible` for locked account and set locked status label. Remove checking for visibility since rows are always visible now