### PR TITLE
SettingsToggle: icon → icon_name

### DIFF
--- a/src/PopoverWidget.vala
+++ b/src/PopoverWidget.vala
@@ -25,16 +25,16 @@ public class QuickSettings.PopoverWidget : Gtk.Box {
 
     construct {
         var screen_reader = new SettingsToggle (
-            new ThemedIcon ("orca-symbolic"),
             _("Screen Reader")
         ) {
+            icon_name = "orca-symbolic",
             settings_uri = "settings://sound"
         };
 
         var onscreen_keyboard = new SettingsToggle (
-            new ThemedIcon ("input-keyboard-symbolic"),
             _("Onscreen Keyboard")
         ) {
+            icon_name = "input-keyboard-symbolic",
             settings_uri = "settings://input/keyboard/behavior"
         };
 

--- a/src/Widgets/DarkModeToggle.vala
+++ b/src/Widgets/DarkModeToggle.vala
@@ -6,12 +6,12 @@
 public class QuickSettings.DarkModeToggle: SettingsToggle {
     public DarkModeToggle () {
         Object (
-            icon: new ThemedIcon ("dark-mode-symbolic"),
             label: _("Dark Mode")
         );
     }
 
     construct {
+        icon_name = "dark-mode-symbolic";
         settings_uri = "settings://desktop/appearance";
 
         var settings = new GLib.Settings ("io.elementary.settings-daemon.prefers-color-scheme");

--- a/src/Widgets/PreventSleepToggle.vala
+++ b/src/Widgets/PreventSleepToggle.vala
@@ -9,12 +9,12 @@ public class QuickSettings.PreventSleepToggle: SettingsToggle {
 
     public PreventSleepToggle () {
         Object (
-            icon: new ThemedIcon ("system-suspend-symbolic"),
             label: _("Prevent Sleep")
         );
     }
 
     construct {
+        icon_name = "system-suspend-symbolic";
         settings_uri = "settings://power";
 
         notify["active"].connect ((obj, pspec) => {
@@ -33,12 +33,12 @@ public class QuickSettings.PreventSleepToggle: SettingsToggle {
                     "Prevent session from idle"
                 );
 
-                icon = new ThemedIcon ("system-suspend-disabled-symbolic");
+                icon_name = "system-suspend-disabled-symbolic";
             } else if (!_prevent_sleep_toggle.active && suspend_cookie > 0 && idle_cookie > 0) {
                 application.uninhibit (suspend_cookie);
                 application.uninhibit (idle_cookie);
 
-                icon = new ThemedIcon ("system-suspend-symbolic");
+                icon_name = "system-suspend-symbolic";
 
                 suspend_cookie = 0;
                 idle_cookie = 0;

--- a/src/Widgets/RotationToggle.vala
+++ b/src/Widgets/RotationToggle.vala
@@ -6,22 +6,22 @@
 public class QuickSettings.RotationToggle: SettingsToggle {
     public RotationToggle () {
         Object (
-            icon: new ThemedIcon ("quick-settings-rotation-locked-symbolic"),
             label: _("Rotation Lock")
         );
     }
 
     construct {
+        icon_name = "quick-settings-rotation-locked-symbolic";
         settings_uri = "settings://display";
 
         var touchscreen_settings = new Settings ("org.gnome.settings-daemon.peripherals.touchscreen");
         touchscreen_settings.bind ("orientation-lock", this, "active", DEFAULT);
 
-        bind_property ("active", this, "icon", SYNC_CREATE, (binding, srcval, ref targetval) => {
+        bind_property ("active", this, "icon-name", SYNC_CREATE, (binding, srcval, ref targetval) => {
             if ((bool) srcval) {
-                targetval = new ThemedIcon ("quick-settings-rotation-locked-symbolic");
+                targetval = "quick-settings-rotation-locked-symbolic";
             } else {
-                targetval = new ThemedIcon ("quick-settings-rotation-allowed-symbolic");
+                targetval = "quick-settings-rotation-allowed-symbolic";
             }
             return true;
         });

--- a/src/Widgets/SettingsToggle.vala
+++ b/src/Widgets/SettingsToggle.vala
@@ -5,21 +5,20 @@
 
 public class QuickSettings.SettingsToggle : Gtk.FlowBoxChild {
     public bool active { get; set; }
-    public Icon icon { get; construct set; }
+    public string icon_name { get; set; }
     public string label { get; construct; }
     public string settings_uri { get; set; default = "settings://"; }
 
     private Gtk.GestureMultiPress middle_click_gesture;
 
-    public SettingsToggle (Icon icon, string label) {
+    public SettingsToggle (string label) {
         Object (
-            icon: icon,
             label: label
         );
     }
 
     construct {
-        var image = new Gtk.Image.from_gicon (icon, MENU);
+        var image = new Gtk.Image ();
 
         var button = new Gtk.ToggleButton () {
             halign = CENTER,
@@ -44,7 +43,7 @@ public class QuickSettings.SettingsToggle : Gtk.FlowBoxChild {
 
         button.bind_property ("active", this, "active", SYNC_CREATE | BIDIRECTIONAL);
 
-        bind_property ("icon", image, "gicon");
+        bind_property ("icon-name", image, "icon-name");
 
         middle_click_gesture = new Gtk.GestureMultiPress (button) {
             button = Gdk.BUTTON_MIDDLE


### PR DESCRIPTION
in GTK4 ToggleButton has a nice `icon_name` property we can bind to, so this just makes things much easier. Made it a settable property instead of construct to future proof for a world where this widget might be created by a model that recycles widgets