### PR TITLE
PopoverWidget: notify when onboard activated in Wayland

### DIFF
--- a/src/PopoverWidget.vala
+++ b/src/PopoverWidget.vala
@@ -117,7 +117,6 @@ public class QuickSettings.PopoverWidget : Gtk.Box {
         });
 
         var applications_settings = new Settings ("org.gnome.desktop.a11y.applications");
-        applications_settings.bind ("screen-keyboard-enabled", onscreen_keyboard, "active", DEFAULT);
         applications_settings.bind ("screen-reader-enabled", screen_reader, "active", DEFAULT);
 
         var glib_settings = new Settings ("io.elementary.desktop.quick-settings");
@@ -146,6 +145,29 @@ public class QuickSettings.PopoverWidget : Gtk.Box {
         current_user_button.clicked.connect (() => {
             stack.visible_child = accounts_view;
         });
+
+        if (!(Gdk.Display.get_default () is Gdk.Wayland.Display)) {
+            applications_settings.bind ("screen-keyboard-enabled", onscreen_keyboard, "active", DEFAULT);
+        } else {
+            onscreen_keyboard.notify["active"].connect (() => {
+                if (!onscreen_keyboard.active) {
+                    return;
+                }
+
+                onscreen_keyboard.active = false;
+
+                var message_dialog = new Granite.MessageDialog (
+                    _("On Screen keyboard is unavailable in the Secure session"),
+                    _("Log out and select “Classic session” to use the On Screen Keyboard."),
+                    new ThemedIcon ("onboard")
+                ) {
+                    badge_icon = new ThemedIcon ("system-log-out"),
+                    transient_for = (Gtk.Window) get_toplevel ()
+                };
+                message_dialog.response.connect (message_dialog.destroy);
+                message_dialog.present ();
+            });
+        }
     }
 
     private async SensorProxy? setup_sensor_proxy () {


### PR DESCRIPTION
Until we have an onscreen keyboard that works in Wayland, show a message to guide folks who need it. I think this is better than hiding or disabling the button and leaving no guidance